### PR TITLE
Make options optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,14 +8,16 @@ import {
 } from './utils'
 
 /**
- * Create an invisible grecaptcha and returns the recaptcha token.
+ * Creates an invisible reCAPTCHA instance, dynamically loading Google's library if necessary, and then returns a user
+ * response token. This is a client-side step, and the token must be sent to the server side for verification as a
+ * separate step. Tokens are single use and can be verified only once.
  * @param {string} sitekey - Your recaptcha sitekey. You can get one here: https://www.google.com/recaptcha/admin.
- * @param {Object} options - The options to create a invisible recaptcha.
+ * @param {Object} [options] - The options to create an invisible reCAPTCHA.
  * @param {string} [options.locale = en] - Language of the captcha. See available language codes https://developers.google.com/recaptcha/docs/language. Auto-detects the user's language if unspecified.
  * @param {string} [options.position = bottomright] - Position the reCAPTCHA badge. Values: bottomright, bottomleft and inline.
  * @returns {string}
  */
-export function execute(sitekey, {locale = 'en', position = 'bottomright'}) {
+export function execute(sitekey, {locale = 'en', position = 'bottomright'} = {}) {
   return new Promise((resolve, reject) => {
     validateRequired(sitekey, 'sitekey')
 


### PR DESCRIPTION
This PR fixes #11 by providing a default value of an empty object.

I considered avoiding allocating an empty object for the default argument, but it would've made the code more verbose:

```javascript
export function execute(sitekey, options) {
  const locale = options && options.locale || 'en'
  const position = options && options.position || 'bottomright'
  // ...
```

In the end I opted for brevity, which is just fine because this is not a performance-critical piece of code.